### PR TITLE
bug fix on version specification, and path search for mbatch site file

### DIFF
--- a/mbatch/mbatch.py
+++ b/mbatch/mbatch.py
@@ -154,7 +154,7 @@ def detect_site():
 def get_site_path():
     # First try ~/.mbatch/*.yml
     home = str(Path.home())
-    homepath = os.path.join(home,".mbatch/*.yml")
+    homepath = os.path.join(home,".mbatch/")
     fs = glob.glob(homepath)
     if len(fs)>=1: return homepath
     # Otherwise get path relative to this module

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements =  ['setuptools>=39',
 
 
 test_requirements = ['pip>=9.0',
-                     'bumpversion>=0.5.',
+                     'bumpversion>=0.5',
                      'wheel>=0.30',
                      'watchdog>=0.8',
                      'flake8>=3.5',


### PR DESCRIPTION
setuptools complained with 
`'bumpversion>=0.5.'`, changed instead to `'bumpversion>=0.5'`

Also,in `mbatch.py`

The `homepath` in `get_site_path()` should not include "*.yml", as this makes the function `load_template()` search for generic site in folder `{home}/.mbatch/.yml/{site}.yml` ...!!, instead of `{home}/.mbatch/{site}.yml`