### PR TITLE
Add SLURM template example to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,7 @@ template: |
   mpirun !CMD
 ``
 Using ``--site mysite`` to specify this template.
+To enable hyper-threading, change ``!THREADS`` to ``!HYPERTHREADS``.
 
 
 Pipeline requirements
@@ -251,6 +252,9 @@ described in the comments below:
 		    # to the script. It does not pass any positional arguments.
 		    # It also explicitly says to use 8 OpenMP threads and
 		    # requests 15 minutes of walltime.
+            # Note: If hyper-threading (2 threads per core) is enabled in SLURM
+            # template, the generated sbatch script will have
+            # OMP_NUM_THREADS=16 and --cpus-per-task=16
 		    stage2:
 		        exec: python
 		        script: stage2.py

--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,42 @@ you can copy the contents of ``~/.local/lib/python3.8/site-packages/mbatch/data/
 (or whatever was the result of the above command) to ``~/.mbatch/``, which is the
 first location that ``mbatch`` looks for site files.
 
+You can also create a custom SLURM template `~/.mbatch/mysite.yml`. For example a site with 8 cores per node and 8GB memory per node would looks like:
+``
+
+default_constraint: None
+default_part: None
+default_qos: None
+default_account: None
+architecture:
+  None:      # constraint name
+    None:    # partition name
+      cores_per_node: 8
+      threads_per_core: 2
+      memory_per_node_gb: 8
+
+
+template: |
+  #!/bin/bash!CONSTRAINT!QOS!PARTITION!ACCOUNT
+  #SBATCH --nodes=!NODES
+  #SBATCH --time=!WALL
+  #SBATCH --ntasks-per-node=!TASKSPERNODE
+  #SBATCH --ntasks=!TASKS
+  #SBATCH --cpus-per-task=!THREADS
+  #SBATCH --job-name=!JOBNAME
+  #SBATCH --output=!OUT_%j.txt
+  #SBATCH --mail-type=FAIL
+  #SBATCH --mail-user=
+
+  export DISABLE_MPI=false
+  export OMP_NUM_THREADS=!THREADS
+  export NUMEXPR_MAX_THREADS=!THREADS
+
+  mpirun !CMD
+``
+Using ``--site mysite`` to specify this template.
+
+
 Pipeline requirements
 ---------------------
 

--- a/example/example.yml
+++ b/example/example.yml
@@ -48,6 +48,9 @@ stages:
   # to the script. It does not pass any positional arguments.
   # It also explicitly says to use 8 OpenMP threads and
   # requests 15 minutes of walltime.
+  # Note: If hyper-threading (2 threads per core) is enabled in SLURM
+  # template, the generated sbatch script will have
+  # OMP_NUM_THREADS=16 and --cpus-per-task=16
   stage2:
     exec: python
     script: stage2.py

--- a/mbatch/mbatch.py
+++ b/mbatch/mbatch.py
@@ -145,8 +145,7 @@ def detect_site():
         sites.append( 'cori' )
         
     if len(sites)==0:
-        warnings.warn('No site specified through --site and did not automatically detect any sites. Using generic SLURM template.')
-        sites.append( 'generic' )
+        raise_exception('No site specified through --site and did not automatically detect any sites. Please create a site configuration first. See https://github.com/simonsobs/mbatch#configuration')
     elif len(sites)==1:
         fprint(HTML(f'<ansiyellow>No site specified through --site; detected <b>{sites[0]}</b> automatically.</ansiyellow>'))
     else:


### PR DESCRIPTION
- If ``--site`` is not specified and can't detect any sites, raise error and let user provide template, instead of using generic SLURM template which does not exist. #23 
- Add guides to create a custom SLURM template.
- Better documentation of how hyper-threading works.