### PR TITLE
Trillium site .yml + allowing "python -u" to be used

### DIFF
--- a/mbatch/data/sites/trillium.yml
+++ b/mbatch/data/sites/trillium.yml
@@ -1,0 +1,33 @@
+
+default_constraint: None
+default_part: None
+default_qos: None
+default_account: None
+architecture:
+  None:
+    None:
+      cores_per_node: 192
+      memory_per_node_gb: 768
+
+template: |
+  #!/bin/bash!CONSTRAINT!QOS!PARTITION!ACCOUNT
+  #SBATCH --nodes=!NODES
+  #SBATCH --time=!WALL
+  #SBATCH --ntasks-per-node=!TASKSPERNODE
+  #SBATCH --cpus-per-task=!THREADS
+  #SBATCH --job-name=!JOBNAME
+  #SBATCH --output=!OUT_%j.txt
+  #SBATCH --mail-type=FAIL
+  #SBATCH --mail-user=
+
+  cd $SLURM_SUBMIT_DIR
+  export DISABLE_MPI=false
+
+  module load StdEnv/2023
+  export I_MPI_JOB_RESPECT_PROCESS_PLACEMENT=disable
+  module load cfitsio
+  module load gsl
+
+  export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
+
+  srun !CMD

--- a/mbatch/mbatch.py
+++ b/mbatch/mbatch.py
@@ -89,7 +89,7 @@ def gitcheck(config,cname,package):
 def get_command(global_vals, stage_configs, stage):
     stage_config = stage_configs[stage]
     execution = stage_config['exec']
-    if not(execution in ['python','python3']):
+    if not(execution in ['python','python3','python -u']):
         raise_exception("Only Python execution "
                         "is currently supported. "
                         "Shell support will be "


### PR DESCRIPTION
Some changes with Trillium's site .yml compared to Niagara:

- Hardware specifications (cores per node, memory per node)
- Usage of standard environment (StdEnv/2023 instead of NiaEnv, see [here for documentation](https://docs.alliancecan.ca/wiki/Migration_to_the_new_standard_environment))
- Not loading Intel compilers by default [as listed here](https://docs.alliancecan.ca/wiki/Standard_software_environments)
- Not loading in `intelmpi/2019u4`, `autotools` (these modules no longer exist on Trillium)
- Not loading in Python 3.8.5 by default (3.8 has reached end of life + default version on Trillium is 3.11.4, if older versions are needed maybe they can be specified directly? Open to suggestions here)

The other minor change allows us to use "python -u" as the `!CMD` prefix which will log to SLURM outputs in real-time / an unbuffered manner, especially in the presence of MPI jobs.